### PR TITLE
Do not try to close the socket if it wasn't opened

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,8 @@ impl AsyncWrite for Connection {
 impl Drop for Connection {
     fn drop(&mut self) {
         let shared = self.shared.lock();
-        let _ = shared.socket.close();
+        if shared.opened {
+            let _ = shared.socket.close();
+        }
     }
 }


### PR DESCRIPTION
Fix `drop` to not close the socket if it wasn't previously opened. This fixes a behaviour where errored connections were raising an exception closing an unopened connection.