### PR TITLE
Remove unnecessary libp2p dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,18 @@ edition = "2021"
 license = "MIT"
 name = "libp2p-websys-transport"
 repository = "https://github.com/vincev/libp2p-websys-transport"
-version = "0.1.4"
+version = "0.1.5"
 
 [dependencies]
 futures = "0.3.26"
+# For enabling js feature in libp2p dependency.
+getrandom = { version = "0.2.3", features = ["js"] }
 js-sys = "0.3.61"
+libp2p-core = { version = "0.39", default-features = false }
 parking_lot = "0.12.1"
 send_wrapper = "0.6.0"
 thiserror = "1.0.38"
 wasm-bindgen = "0.2.84"
-
-[dependencies.libp2p]
-version = "0.51"
-features = ["floodsub", "mplex", "noise", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.61"
@@ -27,4 +26,3 @@ features = [
   "MessageEvent",
   "WebSocket",
 ]
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,12 @@
 // SOFTWARE.
 
 //! Libp2p transports built on [Websys](https://rustwasm.github.io/wasm-bindgen/web-sys/index.html).
-#![warn(clippy::all, rust_2018_idioms, unused_crate_dependencies)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use futures::{future::Ready, io, prelude::*};
-use libp2p::{
-    core::transport::{ListenerId, Transport, TransportError, TransportEvent},
+use libp2p_core::{
     multiaddr::{Multiaddr, Protocol},
+    transport::{ListenerId, Transport, TransportError, TransportEvent},
 };
 use parking_lot::Mutex;
 use send_wrapper::SendWrapper;


### PR DESCRIPTION
Simplify dependencies to depend only on libp2p-core (see #6).